### PR TITLE
support [gist:id=3254906] and fix bug

### DIFF
--- a/pelican_gist/__init__.py
+++ b/pelican_gist/__init__.py
@@ -1,4 +1,4 @@
-# coding: UTF-8 
+# -*- coding: utf-8 -*-
 __title__ = 'pelican-gist'
 __version__ = '0.1.1'
 __author__ = 'Chris Streeter'

--- a/pelican_gist/plugin.py
+++ b/pelican_gist/plugin.py
@@ -128,8 +128,8 @@ def replace_gist_tags(generator):
             # Create a context to render with
             context = generator.context.copy()
             context.update({
-                'script_url': script_url(gist_id, filename),
-                'code': body,
+                'script_url': unicode(script_url(gist_id, filename), 'utf-8'),
+                'code': unicode(body, 'utf-8'),
             })
 
             # Render the template


### PR DESCRIPTION
**CHANGES**
1. support secret gist . e.g.: https://gist.github.com/mckelvin/63c089cf1160117c535a
2. support syntax looks like `[gist:id=3254906]` for gist containing only one file.
3. fix a bug: any gist containing CJK characters will raise `'ascii' codec can't encode characters in position 0-3: ordinal not in range(128).` for Jinja2 is [using Unicode internally](http://jinja.pocoo.org/docs/api/#unicode).
