### PR TITLE
Fixing bug with fetch_gist returning bytes over string

### DIFF
--- a/pelican_gist/plugin.py
+++ b/pelican_gist/plugin.py
@@ -62,7 +62,7 @@ def set_cache(base, gist_id, body, filename=None):
 
 
 def fetch_gist(gist_id, filename=None):
-    """Fetch a gist and return the raw contents."""
+    """Fetch a gist and return the contents as a string."""
     import requests
 
     url = gist_url(gist_id, filename)
@@ -70,9 +70,9 @@ def fetch_gist(gist_id, filename=None):
 
     if response.status_code != 200:
         raise Exception('Got a bad status looking up gist.')
-    body = response.content
+    body = response.text
     if not body:
-        raise Exception('Unable to get the gist content.')
+        raise Exception('Unable to get the gist contents.')
 
     return body
 

--- a/pelican_gist/test_plugin.py
+++ b/pelican_gist/test_plugin.py
@@ -10,6 +10,8 @@ from __future__ import unicode_literals
 import os
 
 from pelican_gist import plugin as gistplugin
+from mock import patch
+import requests.models
 
 
 def test_gist_url():
@@ -90,3 +92,14 @@ def test_set_get_cache():
     # Fetch the same file
     cached = gistplugin.get_cache(path_base, gist_id, filename)
     assert cached == body
+
+
+def test_fetch_gist():
+    """ fetch_gist should return a string with the response content """
+    CODE_BODY = "code"
+    with patch('requests.get') as get:
+        return_response = requests.models.Response()
+        return_response.status_code = 200
+        return_response._content= CODE_BODY.encode()
+        get.return_value = return_response
+        assert gistplugin.fetch_gist(1) == CODE_BODY

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,11 @@ packages = [
 ]
 
 requires = [
-    'requests',
+    'requests>=2.2.0',
+]
+
+tests_require = [
+    'mock>=1.0.1'
 ]
 
 setup(
@@ -40,6 +44,7 @@ setup(
     package_dir={'pelican_gist': 'pelican_gist'},
     include_package_data=True,
     install_requires=requires,
+    tests_require=tests_require,
     license='MIT',
     classifiers=(
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Hi,

pelican-gist was breaking for me with python 3.3, and I figured out it has to do with requests returning a 'bytes' object over the expected string object for fetch_gist. It looks like it was desired for fetch_gist to return a string with the contents, so here's a fix for that.

Tested with Python 3.3 and 2.7.

Thanks!
