### PR TITLE
Solve the problem that it alerts "local variable 'body' referenced before assignment"

### DIFF
--- a/pelican_gist/plugin.py
+++ b/pelican_gist/plugin.py
@@ -108,6 +108,10 @@ def replace_gist_tags(generator):
     should_cache = generator.context.get('GIST_CACHE_ENABLED')
     cache_location = generator.context.get('GIST_CACHE_LOCATION')
     pygments_style = generator.context.get('GIST_PYGMENTS_STYLE')
+    
+    # added by SgtDaJim on 20170809
+    # To solve the problem that it alerts "local variable 'body' referenced before assignment" when compiling blogs.
+    body = None
 
     for article in generator.articles:
         for match in gist_regex.findall(article._content):

--- a/pelican_gist/plugin.py
+++ b/pelican_gist/plugin.py
@@ -109,8 +109,6 @@ def replace_gist_tags(generator):
     cache_location = generator.context.get('GIST_CACHE_LOCATION')
     pygments_style = generator.context.get('GIST_PYGMENTS_STYLE')
     
-    # added by SgtDaJim on 20170809
-    # To solve the problem that it alerts "local variable 'body' referenced before assignment" when compiling blogs.
     body = None
 
     for article in generator.articles:


### PR DESCRIPTION
Solve the problem that it alerts "local variable 'body' referenced before assignment" when compiling blogs using python 3.5