### PR TITLE
update regex for tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+
+python: 
+  - 2.7
+  - 3.6
+
+install: pip install -r requirements.txt
+
+script: pytest

--- a/pelican_gist/plugin.py
+++ b/pelican_gist/plugin.py
@@ -18,7 +18,7 @@ import pygments
 
 logger = logging.getLogger(__name__)
 gist_regex = re.compile(
-    r'(<p>\[gist:id\=([0-9a-fA-F]+)(,file\=([^\]]+))?(,filetype\=([a-zA-Z]+))?\]</p>)')
+    r'(<p>\[gist:id\=([0-9a-fA-F]+)(,file\=([^\],]+))?(,filetype\=([a-zA-Z]+))?\]</p>)')
 gist_template = """<div class="gist">
     <script src='{{script_url}}'></script>
     <noscript>

--- a/pelican_gist/test_plugin.py
+++ b/pelican_gist/test_plugin.py
@@ -12,8 +12,24 @@ import os
 from pelican_gist import plugin as gistplugin
 from mock import patch
 import requests.models
+from gistplugin import gist_regex
 
-
+def test_gist_regex_match():
+    #Test for gist id only
+    match = gist_regex.findall("<p>[gist:id=3254906]</p>")
+    assert match[1] = "3254906"
+    
+    # Test for tag with gist id and filename
+    match = gist_regex.findall("<p>[gist:id=3254906,filename=brew-update-notifier.sh]</p>")
+    assert match[1] = "3254906"
+    assert match[3] = "brew-update-notifier.sh"
+    
+    # Test for tag with gist id, filename, and filetype. 
+    match = gist_regex.findall("<p>[gist:id=3254906,filename=brew-update-notifier.sh,filetype=bash]</p>")
+    assert match[1] = "3254906"
+    assert match[3] = "brew-update-notifier.sh"
+    assert match[5] = "bash"
+    
 def test_gist_url():
     gist_id = str(3254906)
     filename = 'brew-update-notifier.sh'

--- a/pelican_gist/test_plugin.py
+++ b/pelican_gist/test_plugin.py
@@ -12,8 +12,24 @@ import os
 from pelican_gist import plugin as gistplugin
 from mock import patch
 import requests.models
+from pelican_gist.plugin import gist_regex
 
-
+def test_gist_regex_match():
+    #Test for gist id only
+    match = gist_regex.search("<p>[gist:id=3254906]</p>")
+    assert match[2] == "3254906"
+    
+    # Test for tag with gist id and filename
+    match = gist_regex.search("<p>[gist:id=3254906,file=brew-update-notifier.sh]</p>")
+    assert match[2] == "3254906"
+    assert match[4] == "brew-update-notifier.sh"
+    
+    # Test for tag with gist id, filename, and filetype. 
+    match = gist_regex.search("<p>[gist:id=3254906,file=brew-update-notifier.sh,filetype=bash]</p>")
+    assert match[2] == "3254906"
+    assert match[4] == "brew-update-notifier.sh"
+    assert match[6] == "bash"
+    
 def test_gist_url():
     gist_id = str(3254906)
     filename = 'brew-update-notifier.sh'


### PR DESCRIPTION
Exclude commas from filename match so that filetype is not erroneously
appended to gist url.